### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/cmd/trafikgen/download.go
+++ b/cmd/trafikgen/download.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/phille97/trafikinfo/internal/meta"
@@ -126,20 +127,33 @@ func extract(_ context.Context, src, dst string) error {
 				return err
 			}
 			defer reader.Close()
-			path := filepath.Join(dst, file.Name)
-			_ = os.Remove(path)
-			err = os.MkdirAll(path, os.ModePerm)
+			extractPath := filepath.Join(dst, file.Name)
+			absDst, err := filepath.Abs(dst)
+			if err != nil {
+				return err
+			}
+			absExtractPath, err := filepath.Abs(extractPath)
+			if err != nil {
+				return err
+			}
+			// Ensure extractPath is within absDst
+			if !strings.HasPrefix(absExtractPath, absDst+string(os.PathSeparator)) && absExtractPath != absDst {
+				log.Printf("skipping suspicious path: %s (would extract outside of %s)\n", file.Name, absDst)
+				continue
+			}
+			_ = os.Remove(absExtractPath)
+			err = os.MkdirAll(absExtractPath, os.ModePerm)
 			if err != nil {
 				return err
 			}
 			if file.FileInfo().IsDir() {
 				continue
 			}
-			err = os.Remove(path)
+			err = os.Remove(absExtractPath)
 			if err != nil {
 				return err
 			}
-			writer, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+			writer, err := os.OpenFile(absExtractPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/phille97/trafikinfo/security/code-scanning/1](https://github.com/phille97/trafikinfo/security/code-scanning/1)

To prevent arbitrary file access ("Zip Slip"), validate that the computed file path, after joining `dst` and the archive entry name (`file.Name`), does not escape the `dst` directory. The best method is to compute the absolute path for both the destination directory and the output file, and ensure that the resultant file path has the destination directory as its prefix.

Steps:
- After joining `dst` and `file.Name`, compute the cleaned absolute path for both.
- Verify that the resultant file path starts with the destination directory's absolute path (with a path separator suffix to avoid partial matching).
- If this check fails, skip extracting the file and optionally log a warning.
- Make these changes just before any file system operation using the computed `path` (removal, creation, writing).

You may need to add `strings` to the imports if `strings.HasPrefix` is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
